### PR TITLE
feat: add recursive deps

### DIFF
--- a/exercises/npm-registry/src/package.ts
+++ b/exercises/npm-registry/src/package.ts
@@ -1,22 +1,53 @@
-import { RequestHandler } from 'express';
-import got from 'got';
-import { NPMPackage } from './types';
+import { RequestHandler } from "express";
+import got from "got";
+import { minSatisfying } from "semver";
+import { NPMPackage } from "./types";
 
 /**
  * Attempts to retrieve package data from the npm registry and return it
  */
 export const getPackage: RequestHandler = async function (req, res, next) {
   const { name, version } = req.params;
-
+  const dependencyTree = {};
   try {
     const npmPackage: NPMPackage = await got(
-      `https://registry.npmjs.org/${name}`,
+      `https://registry.npmjs.org/${name}`
     ).json();
 
     const dependencies = npmPackage.versions[version].dependencies;
 
-    return res.status(200).json({ name, version, dependencies });
+    for (const [dep, version] of Object.entries(dependencies as Object)) {
+      const subDep = await getDependencies(dep, version);
+      dependencyTree[dep] = { version, dependecies: subDep };
+    }
+
+    return res
+      .status(200)
+      .json({ name, version, dependencies: dependencyTree });
   } catch (error) {
     return next(error);
   }
 };
+
+async function getDependencies(name, version) {
+  return got(`https://registry.npmjs.org/${name}`)
+    .json()
+    .then((npmPackage: any) => {
+      let v = minSatisfying(Object.keys(npmPackage.versions), version);
+
+      if (v) {
+        const dependencyTree = {};
+        const newDeps = npmPackage.versions[v].dependencies;
+        for (const [dep, version] of Object.entries(
+          newDeps || ({} as Object)
+        )) {
+          const subDep = getDependencies(dep, version);
+          dependencyTree[dep] = { version, dependecies: subDep };
+        }
+
+        return dependencyTree;
+      } else {
+        return {};
+      }
+    });
+}


### PR DESCRIPTION
The PR you will be reviewing updates the "/package" endpoint.
It returns all of the transitive dependencies for a package - not only the first order
dependencies. It also brings https://www.npmjs.com/package/semver library, because npm
returns dependency ranges that follow the Semantic Versioning specification
(https://semver.org/). More details can be found at
https://github.com/snyk/jobs/tree/master/exercises/npm-registry as the PR is a
solution to our original home task.